### PR TITLE
Update how we display decimal places for percentages

### DIFF
--- a/app/views/performance/reasons-for-rejection/_metrics.njk
+++ b/app/views/performance/reasons-for-rejection/_metrics.njk
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-one-half">
     {{ appMetric({
       metric: {
-        text: counts[category].percent | numeral('0.00') + "%"
+        text: counts[category].percent | numeral('0.[00]') + "%"
       },
       label: {
         html: counts[category].total | numeral('0,0') + ' of ' + counts.total | numeral('0,0') + ' rejections included this category'
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-one-half">
       {{ appMetric({
         metric: {
-          text: counts[category].monthPercent | numeral('0.00') + "%"
+          text: counts[category].monthPercent | numeral('0.[00]') + "%"
         },
         label: {
           html: counts[category].monthTotal | numeral('0,0') + ' of ' + counts.monthTotal | numeral('0,0') + ' rejections in September included this category'

--- a/app/views/performance/reasons-for-rejection/_table.njk
+++ b/app/views/performance/reasons-for-rejection/_table.njk
@@ -33,26 +33,26 @@
               </a>
             </th>
             <td class="govuk-table__cell govuk-table__cell--numeric">
-              {{ counts[category].items[reason].percent | numeral('0.00') }}%
+              {{ counts[category].items[reason].percent | numeral('0.[00]') }}%
               <span class="govuk-hint govuk-!-margin-bottom-0">
                 {{ counts[category].items[reason].total | numeral('0,0') }} of {{ counts.total | numeral('0,0') }}
               </span>
             </td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
-              {{ ((counts[category].items[reason].total / counts[category].total) * 100) | numeral('0.00') }}%
+              {{ ((counts[category].items[reason].total / counts[category].total) * 100) | numeral('0.[00]') }}%
               <span class="govuk-hint govuk-!-margin-bottom-0">
                 {{ counts[category].items[reason].total | numeral('0,0') }} of {{ counts[category].total | numeral('0,0') }}
               </span>
             </td>
             {% if currentCycle == cycle %}
               <td class="govuk-table__cell govuk-table__cell--numeric">
-                {{ ((counts[category].items[reason].monthTotal / counts.monthTotal) * 100) | numeral('0.00') }}%
+                {{ ((counts[category].items[reason].monthTotal / counts.monthTotal) * 100) | numeral('0.[00]') }}%
                 <span class="govuk-hint govuk-!-margin-bottom-0">
                   {{ counts[category].items[reason].monthTotal | numeral('0,0') }} of {{ counts.monthTotal | numeral('0,0') }}
                 </span>
               </td>
               <td class="govuk-table__cell govuk-table__cell--numeric">
-                {{ ((counts[category].items[reason].monthTotal / counts[category].monthTotal) * 100) | numeral('0.00') }}%
+                {{ ((counts[category].items[reason].monthTotal / counts[category].monthTotal) * 100) | numeral('0.[00]') }}%
                 <span class="govuk-hint govuk-!-margin-bottom-0">
                   {{ counts[category].items[reason].monthTotal | numeral('0,0') }} of {{ counts[category].monthTotal | numeral('0,0') }}
                 </span>


### PR DESCRIPTION
Remove training zeros from the percentages to make them easier to read.

![image](https://user-images.githubusercontent.com/23444/138252608-d7f6eb15-76d8-4344-bb26-5663895265ca.png)
