### PR TITLE
Add impersonation banner

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -30,6 +30,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "core/links";
 @import "core/table";
 @import "core/tag";
+@import "core/impersonating";
 
 // Utilities
 @import "utilities/grid";

--- a/app/assets/sass/core/_impersonating.scss
+++ b/app/assets/sass/core/_impersonating.scss
@@ -1,0 +1,30 @@
+.app-impersonating {
+  @include govuk-font($size: 19, $weight: bold);
+
+  background-color:  govuk-colour("yellow");
+  background: repeating-linear-gradient(
+    -45deg,
+    govuk-colour("yellow"),
+    govuk-colour("yellow") 10px,
+    govuk-colour("black") 10px,
+    govuk-colour("black") 20px
+  );
+}
+
+.app-impersonating .govuk-width-container {
+  background-color: govuk-colour("yellow");
+  padding: 15px;
+}
+
+.app-impersonating .govuk-link {
+  color: inherit;
+}
+
+.app-impersonating__button {
+  padding-top: 2px;
+  padding-bottom: 0px;
+  margin-left: 10px;
+  margin-bottom: 0;
+
+  @include govuk-font($size: 16, $weight: bold);
+}

--- a/app/views/_layout.njk
+++ b/app/views/_layout.njk
@@ -51,6 +51,19 @@
 {% endblock %}
 
 {% block header %}
+
+{% if data.impersonating_id %}
+  <div class="app-impersonating">
+    <div class="govuk-width-container">
+      You are impersonating provider user <a href="/providers/users/{{ data.impersonating_id }}" class="govuk-link">Aaron Allen</a>.
+
+        <a href="/providers/users/{{ data.impersonating_id }}?impersonating_id=" class="govuk-button govuk-button--warning app-impersonating__button" >
+        Stop impersonating
+      </a>
+    </div>
+  </div>
+{% endif %}
+
   {{ govukHeader({
     classes: "app-header--full-border",
     homepageUrl: "/",

--- a/app/views/providers/users/show.html
+++ b/app/views/providers/users/show.html
@@ -36,14 +36,6 @@
     <h1 class="govuk-heading-l">{{ user.first_name }} {{ user.last_name }}</h1>
 
     {% if data.impersonating_id and data.impersonating_id == user.id %}
-      <p class="govuk-body">You are now impersonating this user. <a href="#" class="govuk-link">Visit Manage</a> to see what they see. Any changes made will be linked to you.</p>
-
-      {{ govukButton({
-        href: "/providers/users/" + user.id + "?impersonating_id=",
-        text: "Stop impersonating this user",
-        classes: 'govuk-button--secondary'
-      }) }}
-
     {% else %}
 
       {{ govukButton({


### PR DESCRIPTION
A quick design for a banner that would remind you when you are 'impersonating' another user.

https://trello.com/c/HECoWuUT/181-add-warning-to-support-console-when-a-bat-users-sign-in-as-provider-users

Some quick notes / thoughts:

* when you sign in as provider user, should it take you straight to Manage as that user, rather than stay in the support view? same for if you sign in as a candidate.
* I think the email address in the black banner should still be _your_ email address, and the sign out should still sign _you_ out.
* I've gone deliberately outside the bounds of the normal page design (above the black banner) so that the rest of it can be exactly as the user would see
* is the diagonal stripes too much?

![impersonation-banner](https://user-images.githubusercontent.com/30665/178366310-46c3dc8d-db49-4419-8cc4-c5248c3b5d48.png)

